### PR TITLE
add API routing about articles

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api, format: 'json' do
+  namespace :api, format: "json" do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth"
       resources :articles

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api, format: 'json' do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- articleについてAPIルーティングの実装
`bundle exec rails routes | grep articles`を実行した際の表示は以下になります。

<img width="440" alt="スクリーンショット 2019-11-17 18 05 21" src="https://user-images.githubusercontent.com/26233990/69005387-e6b19a00-0964-11ea-97cc-2e1411fdb57b.png">
