### PR TITLE
fix a test for POST /api/v1/articles

### DIFF
--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     before { allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user) }
 
     it "current_userに紐付いた記事が作成できる" do
-      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+      expect { subject }.to change { current_user.articles.count }.by(1)
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
## 概要
- 記事作成のテストを修正
　理由：ユーザーの情報は、極力 user からの relation で取るのがよいとのことから。