### PR TITLE
devise_auth_tokenを使ったユーザーの新規登録APIの実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::Auth::RegistrationsController < ApplicationController
+end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  protect_from_forgery with: :null_session
 
-  def sign_up_params
-    params.permit(:name, :email, :password, :password_confirmation)
-  end
+  private
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
 
-  def account_update_params
-    params.permit(:name, :email)
-  end
+    def account_update_params
+      params.permit(:name, :email)
+    end
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   protect_from_forgery with: :null_session
 
   private
+
     def sign_up_params
       params.permit(:name, :email, :password, :password_confirmation)
     end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,2 +1,10 @@
-class Api::V1::Auth::RegistrationsController < ApplicationController
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  def sign_up_params
+    params.permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.permit(:name, :email)
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,6 @@ module QiitaClone
                        request_specs: true
     end
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-   config.change_headers_on_each_request = false
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-   config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-   config.headers_names = {:'access-token' => 'access-token',
-                          :'client' => 'client',
-                          :'expiry' => 'expiry',
-                          :'uid' => 'uid',
-                          :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+   config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+   config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+   config.headers_names = {:'access-token' => 'access-token',
+                          :'client' => 'client',
+                          :'expiry' => 'expiry',
+                          :'uid' => 'uid',
+                          :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,9 @@ Rails.application.routes.draw do
   namespace :api, format: "json" do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: 'api/v1/auth/registrations'
+        registrations: "api/v1/auth/registrations",
       }
       resources :articles
-
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,11 @@ Rails.application.routes.draw do
   root "homes#index"
   namespace :api, format: "json" do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: 'api/v1/auth/registrations'
+      }
       resources :articles
+
     end
   end
 end


### PR DESCRIPTION
## 概要
- ユーザー新規登録のAPI の endpoint が POST /api/v1/authになるようルーティングの変更
- registrations_controllerの作成
- initializeの設定


## initializeの設定について
- リクエストごとにトークンを更新する必要なし
- トークンの有効期限は２週間

## 動作確認



<img width="1073" alt="スクリーンショット 2019-12-23 22 10 02" src="https://user-images.githubusercontent.com/26233990/71361734-2d835700-25d7-11ea-99c3-5a09d450fd01.png">

