### PR TITLE
既存 API の修正

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -2,7 +2,8 @@ class Api::V1::ApiController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
   protect_from_forgery with: :null_session
 
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user!
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
+
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,5 +5,4 @@ class Api::V1::ApiController < ActionController::Base
   alias_method :current_user, :current_api_v1_user
   alias_method :authenticate_user!, :authenticate_api_v1_user!
   alias_method :user_signed_in?, :api_v1_user_signed_in?
-
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ApiController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
   protect_from_forgery with: :null_session
 
-  alias_method :current_user, :current_api_v1_user!
+  alias_method :current_user, :current_api_v1_user
   alias_method :authenticate_user!, :authenticate_api_v1_user!
   alias_method :user_signed_in?, :api_v1_user_signed_in?
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :current_user_set_article, only: [:update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
     articles = Article.all

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers ) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
+    let(:headers) {current_user.create_new_auth_token}
 
-    before { allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user) }
 
     it "current_userに紐付いた記事が作成できる" do
       expect { subject }.to change { current_user.articles.count }.by(1)
@@ -54,13 +54,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
     let(:article) { create(:article, user: current_user) }
-
-    before { allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) {current_user.create_new_auth_token}
 
     context "自身が作成した記事を更新する場合" do
       let(:article_id) { article.id }
@@ -82,13 +81,13 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article_id), params: params) }
-
-    before { allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user) }
+    subject { delete(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
+    let(:headers) {current_user.create_new_auth_token}
     let!(:article) { create(:article, user: current_user) }
+
 
     context "自身が作成した記事を削除する場合" do
       let(:article_id) { article.id }

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -40,12 +40,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params, headers: headers ) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    let(:headers) {current_user.create_new_auth_token}
-
+    let(:headers) { current_user.create_new_auth_token }
 
     it "current_userに紐付いた記事が作成できる" do
       expect { subject }.to change { current_user.articles.count }.by(1)
@@ -59,7 +58,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
     let(:article) { create(:article, user: current_user) }
-    let(:headers) {current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自身が作成した記事を更新する場合" do
       let(:article_id) { article.id }
@@ -85,9 +84,8 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    let(:headers) {current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
     let!(:article) { create(:article, user: current_user) }
-
 
     context "自身が作成した記事を削除する場合" do
       let(:article_id) { article.id }


### PR DESCRIPTION
## 概要
- ログインしていないと使えない API は authenticate_user! で弾くようにする。
- ダミコードであるcurrent_userメソッドの削除
- `current_api_v1_user`, `authenticate_api_v1_user!`, `api_v1_user_signed_in?`のalias_methodを定義
- テストでログインが必要な API を叩く際に headers を渡すようにする。
