### PR TITLE
devise_token_auth で実装した API のテストを実装

### DIFF
--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -41,14 +41,11 @@ RSpec/ImplicitExpect:
 RSpec/InstanceVariable:
   Enabled: false
 
-# spec_helper で meta[:aggregate_failures] を設定することで
-# aggregate_failures が全ての spec で有効になる。
-#
-# ほぼ MultipleExpectations についてはチェックされなくなる設定なので注意。
+#  MultipleExpectations についてはチェックされなくなる設定なので注意。
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  Max: 4
+  Enabled: false
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。
@@ -71,4 +68,7 @@ RSpec/NestedGroups:
 # ブロックは初見だと返り値を書いていると気づけないので and_return にしたいが、
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
+  Enabled: false
+
+RSpec/LetSetup:
   Enabled: false

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,10 +1,68 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /api/v1/auth/registrations" do
-    it "works! (now write some real specs)" do
-      get api_v1_auth_registrations_path
-      expect(response).to have_http_status(200)
+RSpec.describe "Requests::Api::V1::Registrations", type: :request do
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "規約に沿った名前、メールアドレス、パスワードを送った場合" do
+      let(:params) { attributes_for(:user) }
+      it "ユーザー登録できる" do
+        expect { subject }.to change { User.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)["data"]
+        header = response.header
+        expect(res["name"]).to eq params[:name]
+        expect(res["email"]).to eq params[:email]
+        expect(res["password"]).to eq params[:password]
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
+      end
+    end
+
+    context "名前が空白だった場合" do
+      let(:params) { attributes_for(:user, name: nil) }
+      it "ユーザー登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        res = JSON.parse(response.body)["errors"]
+        expect(res["name"]).to include "can't be blank"
+      end
+    end
+
+    context "emailが空白だった場合" do
+      let(:params) { attributes_for(:user, email: nil) }
+      it "ユーザー登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        res = JSON.parse(response.body)["errors"]
+        expect(res["email"]).to include "can't be blank"
+      end
+    end
+
+    context "同じemailが既に登録されていた場合" do
+      before { create(:user, email: email) }
+
+      let(:email) { Faker::Internet.email }
+      let(:params) { attributes_for(:user, email: email) }
+      it "ユーザー登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        res = JSON.parse(response.body)["errors"]
+        expect(res["email"]).to include "has already been taken"
+      end
+    end
+
+    context "passwordが空白だった場合" do
+      let(:params) { attributes_for(:user, password: nil) }
+      it "ユーザー登録できない" do
+        expect { subject }.to change { User.count }.by(0)
+        expect(response).to have_http_status(:unprocessable_entity)
+        res = JSON.parse(response.body)["errors"]
+        expect(res["password"]).to include "can't be blank"
+      end
     end
   end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /api/v1/auth/registrations" do
+    it "works! (now write some real specs)" do
+      get api_v1_auth_registrations_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "GET /api/v1/auth/sessions" do
+    it "works! (now write some real specs)" do
+      get api_v1_auth_sessions_index_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,10 +1,77 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Sessions", type: :request do
-  describe "GET /api/v1/auth/sessions" do
-    it "works! (now write some real specs)" do
-      get api_v1_auth_sessions_index_path
-      expect(response).to have_http_status(200)
+  describe "POST /api/v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
+
+    context "登録済みの正しいユーザー情報を送った場合" do
+      let!(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: user.email, password: user.password) }
+
+      it "ログインできる" do
+        subject
+        header = response.header
+        expect(response).to have_http_status(:ok)
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+      end
+    end
+
+    context "emailが一致しない場合" do
+      let!(:user) { create(:user) }
+      let(:params) { attributes_for(:user, password: user.password) }
+
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        header = response.header
+        expect(response).to have_http_status(:unauthorized)
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+      end
+    end
+
+    context "passwordが一致しない場合" do
+      let!(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: user.email) }
+
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        header = response.header
+        expect(response).to have_http_status(:unauthorized)
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/auth/sign_in" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+
+    context "ログアウトするための正しいユーザー情報を送った場合" do
+      let(:user) { create(:user) }
+      let!(:headers) { user.create_new_auth_token }
+
+      it "ログアウトできる" do
+        expect { subject }.to change { user.reload.tokens.count }.from(1).to(0)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "誤った情報を送った場合" do
+      let(:user) { create(:user) }
+      let!(:token) { user.create_new_auth_token }
+      let!(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
+
+      it "ログアウトできない" do
+        subject
+        expect(response).to have_http_status(:not_found)
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "User was not found or was not logged in."
+      end
     end
   end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     subject { post(api_v1_user_session_path, params: params) }
 
     context "登録済みの正しいユーザー情報を送った場合" do
-      let!(:user) { create(:user) }
+      let(:user) { create(:user) }
       let(:params) { attributes_for(:user, email: user.email, password: user.password) }
 
       it "ログインできる" do
@@ -18,7 +18,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     end
 
     context "emailが一致しない場合" do
-      let!(:user) { create(:user) }
+      let(:user) { create(:user) }
       let(:params) { attributes_for(:user, password: user.password) }
 
       it "ログインできない" do
@@ -33,7 +33,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
     end
 
     context "passwordが一致しない場合" do
-      let!(:user) { create(:user) }
+      let(:user) { create(:user) }
       let(:params) { attributes_for(:user, email: user.email) }
 
       it "ログインできない" do


### PR DESCRIPTION
## 概要
- devise_token_authでのユーザー登録、ログイン、ログアウトについてテストを実装
- rubocopの設定変更


## rubocopの設定変更について
RSpec/LetSetupを無効にしてlet!での宣言でアラートが出ないように変更
RSpec/MultipleExpectationsを無効にして複数のexpectが記述されいてもアラートが出ないように変更