### PR TITLE
Markdown を Syntax Highlight で表示するように修正

### DIFF
--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Router from "./router/router";
 import Header from "./container/Header.vue";
 import Vuetify from "vuetify";
+import "highlight.js/styles/monokai.css";
 import "vuetify/dist/vuetify.min.css";
 
 Vue.use(Vuetify);

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -8,7 +8,7 @@
       <h1 class="article-title">{{ article.title }}</h1>
     </v-layout>
     <v-layout class="article-body-container">
-      <div id="article-body">{{ article.body }}</div>
+      <div id="article-body" v-html="compiledMarkdown"></div>
     </v-layout>
   </v-container>
 </template>
@@ -17,6 +17,8 @@
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import TimeAgo from "vue2-timeago";
+import marked from "marked";
+import hljs from "highlight.js";
 @Component({
   components: {
     TimeAgo
@@ -26,6 +28,38 @@ export default class ArticleContainer extends Vue {
   article: any = "";
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
+  }
+  async created(): Promise<void> {
+    // Add 'hljs' class to code tag
+    const renderer = new marked.Renderer();
+    renderer.code = function(code, language) {
+      return (
+        "<pre" +
+        '><code class="hljs">' +
+        hljs.highlightAuto(code).value +
+        "</code></pre>"
+      );
+    };
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: "",
+      highlight: function(code, lang) {
+        if (!lang || lang == "default") {
+          return hljs.highlightAuto(code, [lang]).value;
+        } else {
+          try {
+            return hljs.highlight(lang, code, true).value;
+          } catch (e) {
+            // Do nonthing!
+          }
+        }
+      }
+    });
+  }
+  get compiledMarkdown() {
+    return marked(this.article.body);
   }
   async fetchArticle(id: string): Promise<void> {
     await axios
@@ -46,7 +80,7 @@ export default class ArticleContainer extends Vue {
   margin-bottom: 1em;
 }
 .article-container {
-  margin: 2em;
+  margin-top: 2em;
 }
 .article-title {
   font-size: 2.5em;


### PR DESCRIPTION
## 概要
Markdown を Syntax Highlight で表示するように修正
<img width="958" alt="スクリーンショット 2020-02-25 12 27 31" src="https://user-images.githubusercontent.com/26233990/75212421-3b697a00-57ca-11ea-97c3-0bce0436b385.png">
