### PR TITLE
 既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.all
+    articles = Article.published
     render json: articles
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article
   end
 
@@ -30,7 +30,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   private
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 
     def current_user_set_article

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :"status"
   belongs_to :user
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at, :"status"
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq Article.published.count
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at",  "status", "user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
       expect(response).to have_http_status(:ok)
     end
   end
@@ -42,6 +42,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
+
     context "指定したidの記事が下書き状態だった場合" do
       let(:article) { create(:article, :draft) }
       let(:article_id) { article.id }
@@ -53,22 +54,22 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
-    context "公開状態の記事を作成した場合" do
 
-    let(:params) { { article: attributes_for(:article, :published) } }
-    let(:current_user) { create(:user) }
-    let(:headers) { current_user.create_new_auth_token }
+    context "公開状態の記事を作成した場合" do
+      let(:params) { { article: attributes_for(:article, :published) } }
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "current_userに紐付いた公開記事が作成できる" do
         expect { subject }.to change { current_user.articles.published.count }.by(1)
         expect(response).to have_http_status(:ok)
       end
     end
-    context "下書きの記事を作成した場合" do
 
-    let(:params) { { article: attributes_for(:article, :draft) } }
-    let(:current_user) { create(:user) }
-    let(:headers) { current_user.create_new_auth_token }
+    context "下書きの記事を作成した場合" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "current_userに紐付いた下書き記事が作成できる" do
         expect { subject }.to change { current_user.articles.draft.count }.by(1)
@@ -92,7 +93,6 @@ RSpec.describe "Api::V1::Articles", type: :request do
                               change { Article.find(article_id).body }.from(article.body).to(params[:article][:body]) &
                               change { Article.find(article_id).status }.from(article.status).to(params[:article][:status]) &
                               not_change { Article.find(article_id).created_at }
-        binding.pry
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,13 +4,16 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
     subject { get(api_v1_articles_path) }
 
-    before { create_list(:article, 3) }
+    before do
+      create_list(:article, 2, :draft)
+      create_list(:article, 3, :published)
+    end
 
-    it "記事の一覧が取得できる" do
+    it "公開記事のみ一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
-      expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
+      expect(res.length).to eq Article.published.count
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at",  "status", "user"]
       expect(response).to have_http_status(:ok)
     end
   end
@@ -18,8 +21,8 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定したidの記事が存在する場合" do
-      let(:article) { create(:article) }
+    context "指定したidの公開記事が存在する場合" do
+      let(:article) { create(:article, :published) }
       let(:article_id) { article.id }
       it "指定した記事が取得できる" do
         subject
@@ -28,6 +31,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
         expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "published"
         expect(response).to have_http_status(:ok)
       end
     end
@@ -38,27 +42,47 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
+    context "指定したidの記事が下書き状態だった場合" do
+      let(:article) { create(:article, :draft) }
+      let(:article_id) { article.id }
+      it "記事が取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
+    context "公開状態の記事を作成した場合" do
 
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    it "current_userに紐付いた記事が作成できる" do
-      expect { subject }.to change { current_user.articles.count }.by(1)
-      expect(response).to have_http_status(:ok)
+      it "current_userに紐付いた公開記事が作成できる" do
+        expect { subject }.to change { current_user.articles.published.count }.by(1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+    context "下書きの記事を作成した場合" do
+
+    let(:params) { { article: attributes_for(:article, :draft) } }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+      it "current_userに紐付いた下書き記事が作成できる" do
+        expect { subject }.to change { current_user.articles.draft.count }.by(1)
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 
   describe "PATCH /api/v1/articles/:id" do
     subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:current_user) { create(:user) }
-    let(:article) { create(:article, user: current_user) }
+    let(:article) { create(:article, user: current_user, status: "draft") }
     let(:headers) { current_user.create_new_auth_token }
 
     context "自身が作成した記事を更新する場合" do
@@ -66,7 +90,9 @@ RSpec.describe "Api::V1::Articles", type: :request do
       it "記事の内容を更新できる" do
         expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
                               change { Article.find(article_id).body }.from(article.body).to(params[:article][:body]) &
+                              change { Article.find(article_id).status }.from(article.status).to(params[:article][:status]) &
                               not_change { Article.find(article_id).created_at }
+        binding.pry
         expect(response).to have_http_status(:ok)
       end
     end


### PR DESCRIPTION
## 概要
以下の処理に対応するためにarticles_controllerを修正
1. 公開されている記事だけ取得できるようにする
2. 記事を作成する場合は、記事の公開/非公開を選択できるようにする

- 上記のテストを追加するためapi/v1/articles_spec を修正