### PR TITLE
下書き記事の一覧/詳細 のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,12 +1,12 @@
 class Api::V1::Articles::DraftsController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:index, :show]
   def index
-    articles = Article.draft
+    articles = current_user.articles.draft
     render json: articles
   end
 
   def show
-    article = Article.draft.find(params[:id])
+    article = current_user.articles.find(params[:id])
     render json: article
   end
 end

--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::Articles::DraftsController < Api::V1::ApiController
+  before_action :authenticate_user!, only: [:index, :show]
+  def index
+    articles = Article.draft
+    render json: articles
+  end
+
+  def show
+    article = Article.draft.find(params[:id])
+    render json: article
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
         sessions: "api/v1/auth/sessions",
       }
       namespace :articles do
-        resources :drafts only: [:index, :show]
+        resources :drafts, only: [:index, :show]
       end
       resources :articles
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
         sessions: "api/v1/auth/sessions",
       }
+      namespace :articles do
+        resources :drafts only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    it "works! (now write some real specs)" do
+      get api_v1_articles_drafts_index_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
     end
   end
 
-  describe "GET /api/v1/articles/drafts:id" do
+  describe "GET /api/v1/articles/drafts/:id" do
     subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
 
     let(:current_user) { create(:user) }

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,10 +1,75 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   describe "GET /api/v1/articles/drafts" do
-    it "works! (now write some real specs)" do
-      get api_v1_articles_drafts_index_path
-      expect(response).to have_http_status(200)
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let!(:article1) { create(:article, :draft, user: current_user) }
+    let!(:article2) { create(:article, :published, user: current_user) }
+    let!(:article3) { create(:article, :draft) }
+    let!(:article4) { create(:article, :draft) }
+
+    context "ログイン時の場合" do
+      let(:headers) { current_user.create_new_auth_token }
+      it "自分が書いた下書き記事一覧が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq current_user.articles.draft.count
+        expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "自分が書いた下書き記事一覧が取得できない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "You need to sign in or sign up before continuing."
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/articles/drafts:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    let(:current_user) { create(:user) }
+
+    context "ログイン状態で指定した下書き記事が存在する場合" do
+      let(:headers) { current_user.create_new_auth_token }
+      let(:article) { create(:article, :draft, user: current_user) }
+      let(:article_id) { article.id }
+      it "自分が書いた下書き記事を取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "draft"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ログイン状態で指定した下書き記事が存在しない場合" do
+      let(:headers) { current_user.create_new_auth_token }
+      let(:article) { create(:article, :draft, user: current_user) }
+      let(:article_id) { 99999 }
+      it "自分が書いた下書き記事を取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "ログインせず指定した下書き記事が存在する場合" do
+      let(:article) { create(:article, :draft, user: current_user) }
+      let(:article_id) { article.id }
+      it "自分が書いた下書き記事を取得できない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "You need to sign in or sign up before continuing."
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
- draftsコントローラーの実装
- ルーティングの調整
- テストの実装



endpoint 以下の通り
- index: /api/v1/articles/draft
- show: /api/v1/articles/draft/:id
